### PR TITLE
Ignore VS code and IntelliJ settings files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 .build/
 TestProject/
 
+# VScode or IntelliJ
+.vscode
+.idea
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
Added two lines to `.gitignore` file to prevent conflicting workspace settings from overriding each other.