### PR TITLE
Allow minter address to revoke role

### DIFF
--- a/ape-config.yaml
+++ b/ape-config.yaml
@@ -1,4 +1,28 @@
 name: Cloud AUD
+
 plugins:
   - name: vyper
   - name: infura
+
+default_ecosystem: ethereum
+
+ethereum:
+  ropsten:
+    default_provider: geth
+  rinkeby:
+    default_provider: geth
+  goerli:
+    default_provider: geth
+  mainnet:
+    default_provider: geth
+
+geth:
+  ethereum:
+    ropsten:
+      uri: https://rpc.ankr.com/eth_ropsten
+    rinkeby:
+      uri: https://rpc.ankr.com/eth_rinkeby
+    goerli:
+      uri: https://rpc.ankr.com/eth_goerli
+    mainnet:
+      uri: https://rpc.ankr.com/eth

--- a/ape-config.yaml
+++ b/ape-config.yaml
@@ -2,7 +2,7 @@ name: Cloud AUD
 
 plugins:
   - name: vyper
-  - name: infura
+  - name: optimism
 
 default_ecosystem: ethereum
 
@@ -16,6 +16,10 @@ ethereum:
   mainnet:
     default_provider: geth
 
+optimism:
+  mainnet:
+    default_provider: geth
+
 geth:
   ethereum:
     ropsten:
@@ -26,3 +30,9 @@ geth:
       uri: https://rpc.ankr.com/eth_goerli
     mainnet:
       uri: https://rpc.ankr.com/eth
+
+  optimism:
+    mainnet:
+      uri: https://rpc.ankr.com/optimism
+    testnet:
+      uri: https://rpc.ankr.com/optimism_testnet

--- a/contracts/Token.vy
+++ b/contracts/Token.vy
@@ -147,6 +147,10 @@ def removeMinter(target: address) -> bool:
 
 @external
 def revokeMinter() -> bool:
+    """
+    @notice Function to revoke own minter role from sender.
+    @return A boolean that indicates if the operation was successful.
+    """
     assert self.isMinter[msg.sender] == True, "Sender is not a minter"
     self.isMinter[msg.sender] = False
     return True

--- a/contracts/Token.vy
+++ b/contracts/Token.vy
@@ -131,6 +131,11 @@ def mint(receiver: address, amount: uint256) -> bool:
 
 @external
 def addMinter(target: address) -> bool:
+    """
+    @notice Function to grant minter role to targeted address.
+    @param target Address to have token minter role granted.
+    @return A boolean that indicates if the operation was successful.
+    """
     assert msg.sender == self.owner
     assert target != ZERO_ADDRESS, "Cannot add null address as minter"
     self.isMinter[target] = True

--- a/contracts/Token.vy
+++ b/contracts/Token.vy
@@ -143,3 +143,11 @@ def removeMinter(target: address) -> bool:
     assert self.isMinter[target] == True, "Targeted address is not a minter"
     self.isMinter[target] = False
     return True
+
+
+@external
+def revokeMinter() -> bool:
+    assert self.isMinter[msg.sender] == True, "Sender is not a minter"
+    self.isMinter[msg.sender] = False
+    return True
+

--- a/contracts/Token.vy
+++ b/contracts/Token.vy
@@ -144,6 +144,11 @@ def addMinter(target: address) -> bool:
 
 @external
 def removeMinter(target: address) -> bool:
+    """
+    @notice Function to remove minter role to targeted address.
+    @param target Address to have token minter role removed.
+    @return A boolean that indicates if the operation was successful.
+    """
     assert msg.sender == self.owner
     assert self.isMinter[target] == True, "Targeted address is not a minter"
     self.isMinter[target] = False

--- a/tests/test_minter_role.py
+++ b/tests/test_minter_role.py
@@ -72,3 +72,40 @@ def test_remove_minter_targeting_zero_address(token, owner, ZERO_ADDRESS):
     with pytest.raises(ape.exceptions.ContractLogicError) as exc_info:
         token.removeMinter(target, sender=owner)
     assert exc_info.value.args[0] == "Targeted address is not a minter"
+
+
+def test_revoke_minter(token, owner, accounts):
+    """
+    Test revoking minter role from address granted minter role by owner
+    """
+    target = accounts[1]
+    token.addMinter(target, sender=owner)
+    assert token.isMinter(target) == True
+    token.revokeMinter(sender=target)
+    assert token.isMinter(target) == False
+
+
+def test_revoke_minter_by_non_minter(token, accounts):
+    """
+    Test revoking minter role from address never granted minter role
+    Must trigger a ContractLogicError (ape.exceptions.ContractLogicError)
+    """
+    target = accounts[1]
+    with pytest.raises(ape.exceptions.ContractLogicError) as exc_info:
+        token.revokeMinter(sender=target)
+    assert exc_info.value.args[0] == "Sender is not a minter"
+
+
+def test_revoke_minter(token, owner, accounts):
+    """
+    Test revoking minter role from address granted minter role by owner, once revoked
+    Must trigger a ContractLogicError (ape.exceptions.ContractLogicError)
+    """
+    target = accounts[1]
+    token.addMinter(target, sender=owner)
+    assert token.isMinter(target) == True
+    token.revokeMinter(sender=target)
+    assert token.isMinter(target) == False
+    with pytest.raises(ape.exceptions.ContractLogicError) as exc_info:
+        token.revokeMinter(sender=target)
+    assert exc_info.value.args[0] == "Sender is not a minter"


### PR DESCRIPTION
> This will prevent frequent exposures of owner address by allowing previously granted minter role to be revoked by its grantee.

- @aekasitt 