### PR TITLE
Test transferOwnership

### DIFF
--- a/tests/test_ownership.py
+++ b/tests/test_ownership.py
@@ -40,3 +40,22 @@ def test_transfer_ownership_by_non_owner(token, owner, receiver):
         token.transferOwnership(owner, sender=receiver)
     assert exc_info.value.args[0] == "Access denied."
     assert token.owner() == owner
+
+def test_transfer_ownership_to_zero_address(token, owner, ZERO_ADDRESS):
+    """
+    Test transferring ownership of contract from original owner to a zero address.
+    Must trigger an ape.exceptions.ContractLogicError when trasferOwnership is called.
+    Contract owner must remain unchanged.
+    """
+    assert token.owner() == owner
+    token.mint(owner, 1000, sender=owner)
+    assert token.balanceOf(owner) == 1000
+
+    ### Attempt to transfer ownership ###
+    new_owner = ZERO_ADDRESS
+    with pytest.raises(ape.exceptions.ContractLogicError) as exc_info:
+        token.transferOwnership(new_owner, sender=owner)
+    assert exc_info.value.args[0] == "Cannot add null address as owner."
+
+    ### Ownership remains unchanged ###
+    assert token.owner() == owner

--- a/tests/test_ownership.py
+++ b/tests/test_ownership.py
@@ -5,7 +5,8 @@ import pytest
 
 def test_transfer_ownership(token, owner, receiver):
     """
-    Test transferring ownership from one address to another.
+    Test transferring ownership from owner address to another then mint by original owner address.
+    Must trigger an ape.exceptions.ContractLogicError when minting post ownership transfer
     """
     assert token.owner() == owner
     token.mint(owner, 1000, sender=owner)

--- a/tests/test_ownership.py
+++ b/tests/test_ownership.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3.8
 import ape
 import pytest
 

--- a/tests/test_ownership.py
+++ b/tests/test_ownership.py
@@ -13,9 +13,17 @@ def test_transfer_ownership(token, owner, receiver):
     assert token.balanceOf(owner) == 1000
 
     # transfer ownership to received
-    token.transferOwnership(receiver, sender=owner)
+    receipt = token.transferOwnership(receiver, sender=owner)
     assert token.owner() != owner
     assert token.owner() == receiver
+
+    # ensure OwnershipTransfer event was emitted
+    logs = receipt.decode_logs(token.OwnershipTransfer)
+    assert len(list(logs)) == 1
+    for log in logs:
+        assert log.previousOwner == owner
+        assert log.newOwner == receiver
+    del logs, receipt
 
     # test that owner can no longer mint
     with pytest.raises(ape.exceptions.ContractLogicError) as exc_info:

--- a/tests/test_ownership.py
+++ b/tests/test_ownership.py
@@ -25,3 +25,18 @@ def test_transfer_ownership(token, owner, receiver):
     # test that the new owner can mint
     token.mint(receiver, 101, sender=receiver)
     assert token.balanceOf(receiver) == 101
+
+def test_transfer_ownership_by_non_owner(token, owner, receiver):
+    """
+    Test transferring ownership from non-owner to owner address.
+    Must trigger an ape.exceptions.ContractLogicError
+    Contract owner must remain unchanged.
+    """
+    assert token.owner() == owner
+    token.mint(owner, 1000, sender=owner)
+    assert token.balanceOf(owner) == 1000
+
+    with pytest.raises(ape.exceptions.ContractLogicError) as exc_info:
+        token.transferOwnership(owner, sender=receiver)
+    assert exc_info.value.args[0] == "Access denied."
+    assert token.owner() == owner

--- a/tests/test_ownership.py
+++ b/tests/test_ownership.py
@@ -26,6 +26,7 @@ def test_transfer_ownership(token, owner, receiver):
     token.mint(receiver, 101, sender=receiver)
     assert token.balanceOf(receiver) == 101
 
+
 def test_transfer_ownership_by_non_owner(token, owner, receiver):
     """
     Test transferring ownership from non-owner to owner address.
@@ -36,10 +37,15 @@ def test_transfer_ownership_by_non_owner(token, owner, receiver):
     token.mint(owner, 1000, sender=owner)
     assert token.balanceOf(owner) == 1000
 
+    ### Attempt to transfer ownership ###
+    non_owner = receiver
     with pytest.raises(ape.exceptions.ContractLogicError) as exc_info:
-        token.transferOwnership(owner, sender=receiver)
+        token.transferOwnership(owner, sender=non_owner)
     assert exc_info.value.args[0] == "Access denied."
+
+    ### Ownership remains unchanged ###
     assert token.owner() == owner
+
 
 def test_transfer_ownership_to_zero_address(token, owner, ZERO_ADDRESS):
     """


### PR DESCRIPTION
Wrote a bit more extensive tests for transferOwnership method recently added with access control in mind and whether or not the event excepted to emit, OwnershipTransfer, was emitted or not.