### PR TITLE
Dockerize project

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM python:3.9-slim as builder
+
+
+# Install Linux dependencies.
+RUN apt-get update \
+    && apt-get install -y gcc openssh-client git \
+    && apt-get clean
+
+# Copy files and set working directory.
+COPY . /app
+WORKDIR /app
+
+# Install Python dependencies.
+RUN pip install --upgrade pip && \
+    pip install --user -r requirements.txt && \
+    pip install --user -r docs/requirements.txt
+
+# Set up ape.
+RUN /root/.local/bin/ape plugins install . && \
+    ape compile --size
+
+# Run the container.
+ENTRYPOINT bash

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,1 @@
+docker build -t caud .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-eth-ape==0.5.2
+eth-ape==0.5.*
 pytest

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,1 @@
+docker run --rm --name caud -v "$(pwd):/app" -it caud


### PR DESCRIPTION
Ape can be difficult to set up locally, and does not always run the same on different
environment. For this reason, we offer a docker image with everything ready to get
started.
