### PR TITLE
Remove Ethereum and replace Mumbai with Amoy

### DIFF
--- a/ape-config.yaml
+++ b/ape-config.yaml
@@ -4,27 +4,15 @@ plugins:
   - name: vyper
   - name: polygon
 
-default_ecosystem: ethereum
-
-ethereum:
-  goerli:
-    default_provider: geth
-  mainnet:
-    default_provider: geth
+default_ecosystem: polygon
 
 polygon:
   mainnet:
     default_provider: geth
 
 geth:
-  ethereum:
-    goerli:
-      uri: https://rpc.ankr.com/eth_goerli
-    mainnet:
-      uri: https://rpc.ankr.com/eth
-
   polygon:
     mainnet:
       uri: https://rpc.ankr.com/polygon
-    mumbai:
-      uri: https://rpc.ankr.com/polygon_mumbai
+    amoy:
+      uri: https://rpc.ankr.com/polygon_amoy


### PR DESCRIPTION
[CFT-2884]

## What?

Migrate from Mumbai testnet to Amoy testnet.

## Why?

From [this article](https://polygon.technology/blog/introducing-the-amoy-testnet-for-polygon-pos):

> The beloved and widely used Mumbai testnet for Polygon PoS uses Ethereum’s Goerli testnet as its root chain. This means Mumbai counts on Goerli for block production. 
>
> But Goerli is currently scheduled for deprecation, by the end of Q1 2024, with major RPC providers planning to pull support. Although the exact timing isn’t known, the writing is on the wall.
>
> No Goerli = broken Mumbai. The community consensus across the Polygon ecosystem has been to deprecate Mumbai in tandem with Goerli. 
>
> When Goerli goes dark, so will Mumbai.

## How?

By replacing the RPC provider to Amoy, and any mentions of Mumbai.

I also removed the Ethereum networks as we don't use them.

## Testing?

https://www.oklink.com/amoy/token/0x7b7B0D664a6929521d189561F26dB4F77B8E18dd


[CFT-2884]: https://cloudfloat.atlassian.net/browse/CFT-2884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ